### PR TITLE
lock expo with native shutter

### DIFF
--- a/LongExpTimeLapse/autoexec.ash
+++ b/LongExpTimeLapse/autoexec.ash
@@ -2,7 +2,3 @@ t app appmode photo
 sleep 1
 t ia2 -ae still_exp P X Y
 sleep 1
-t app button shutter PR
-sleep A
-d:\autoexec.ash
-REBOOT yes


### PR DESCRIPTION
what do you think to allow the user to use the native shutter? Remiving this parte of the code we just lock the exp and free the cam, with it we can take just one photo or config the cam to use what timelapse configuration that we want, and all this using the wifi app (free cam). I'm using it this way for a while and it is very nice.
