### PR TITLE
updated to work with latest firmware

### DIFF
--- a/HERO2Autoexec/LoopVideo/autoexec.ash
+++ b/HERO2Autoexec/LoopVideo/autoexec.ash
@@ -1,7 +1,8 @@
-t gpio 43 sw out0
-sleep X
+sleep 1
 t gpio 43 sw out1
 t gpio 43 sw out0
-sleep 5
+sleep 10
+t gpio 43 sw out1
+t gpio 43 sw out0
 d:\autoexec.ash
 reboot yes


### PR DESCRIPTION
- add preceding button press (line 2).  Without this, the new firmware only processes on start/stop per execution, effectively generating video and pause, each for same length (sum of sleeps).
- added default time (so users are not forced to edit)
- moved pause sleep to beginning.  allows for startup and file write. increased reliability.
- reduced default pause to 1 sec. minimum reliable value.
- suggest updating troubleshooting to include final CR (empty line at EOF).  Will not execute without it.